### PR TITLE
update killbill-oss-parent and killbill-api.version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-oss-parent</artifactId>
-        <version>0.145.1</version>
+        <version>0.145.2</version>
     </parent>
     <groupId>org.kill-bill.billing.plugin</groupId>
     <artifactId>killbill-plugin-api</artifactId>
@@ -50,6 +50,6 @@
         <url>https://github.com/killbill/killbill-plugin-api/issues</url>
     </issueManagement>
     <properties>
-        <killbill-api.version>0.54.0-ec68485-SNAPSHOT</killbill-api.version>
+        <killbill-api.version>0.54.0-0010563-SNAPSHOT</killbill-api.version>
     </properties>
 </project>


### PR DESCRIPTION
- killbill-api.version: from 0.54.0-ec68485-SNAPSHOT to 0.54.0-0010563-SNAPSHOT (`<xxx>0010563` is the latest and required. Otherwise there's compile error in main `killbill` repo)

- killbill-oss-parent: from 0.145.1 to 0.145.2 (so it is the with other library in `work-for-release-0.23.x` branches)