### PR TITLE
Created TenantMetadata Pojo for Tenant Metadata Object

### DIFF
--- a/notification/src/main/java/org/killbill/billing/notification/plugin/api/TenantMetadata.java
+++ b/notification/src/main/java/org/killbill/billing/notification/plugin/api/TenantMetadata.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2022 Groupon, Inc
+ * Copyright 2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.notification.plugin.api;
+
+import java.util.UUID;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class TenantMetadata {
+
+    private final UUID id;
+    private final String key;
+
+    @JsonCreator
+    public TenantMetadata(@JsonProperty("id") final UUID id, @JsonProperty("key") final String key) {
+        this.id = id;
+        this.key = key;
+    }
+
+    @JsonCreator
+    public TenantMetadata(@JsonProperty("key") final String key) {
+        this.id = null;
+        this.key = key;
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+}


### PR DESCRIPTION
Created TenantMetadata Pojo for Tenant Metadata Object to save Tenant Config Update and delete metadata as object instead of String

Hi @reshmabidikar @pierre 