### PR TITLE
bump version to 0.55, use killbill-oss-parent:0.147

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,4 +7,4 @@ on:
 
 jobs:
   ci:
-    uses: killbill/gh-actions-shared/.github/workflows/ci.yml@main
+    uses: killbill/gh-actions-shared/.github/workflows/ci.yml@java21

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -7,4 +7,4 @@ on:
 
 jobs:
   analyze:
-    uses: killbill/gh-actions-shared/.github/workflows/codeql-analysis.yml@main
+    uses: killbill/gh-actions-shared/.github/workflows/codeql-analysis.yml@java21

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,11 +22,11 @@ jobs:
     steps:
       - name: Checkout code
         if: github.event.inputs.perform_version == ''
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
       - name: Checkout full repository
         # Required when performing an existing release.
         if: github.event.inputs.perform_version != ''
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
         with:
           fetch-depth: '0'
       - name: Setup git user
@@ -38,14 +38,10 @@ jobs:
           git config --global user.name "Kill Bill core team"
           git config --global url."https://${BUILD_USER}:${BUILD_TOKEN}@github.com/".insteadOf "git@github.com:"
       - name: Configure Java
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v5
         with:
-          java-version: 11
-      - name: Configure Sonatype mirror
-        uses: s4u/maven-settings-action@v2.3.0
-        # Go to Sonatype directly to avoid delay syncs (could get rid of this if actions/setup-java were to support mirrors).
-        with:
-          mirrors: '[{"id": "oss-releases", "name": "Sonatype releases", "mirrorOf": "*", "url": "https://oss.sonatype.org/content/repositories/releases/"}]'
+          java-version: 21
+          distribution: temurin
       - name: Download Java dependencies
         # We do as much as we can, but it may not be enough (https://issues.apache.org/jira/browse/MDEP-82)
         run: |
@@ -64,19 +60,20 @@ jobs:
           # Will be pushed as part of the release process, only if the release is successful
           git commit -m "pom.xml: update killbill-oss-parent to ${{ github.event.inputs.parent_version }}"
       - name: Configure settings.xml for release
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v5
         with:
-          java-version: 11
-          server-id: ossrh-releases
-          server-username: OSSRH_USER
-          server-password: OSSRH_PASS
+          java-version: 21
+          distribution: temurin
+          server-id: central
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
           gpg-private-key: ${{ secrets.GPG_SIGNING_KEY }}
           gpg-passphrase: GPG_PASSPHRASE
       - name: Release artifacts
         if: github.event.inputs.perform_version == ''
         env:
-          OSSRH_USER: ${{ secrets.OSSRH_USER }}
-          OSSRH_PASS: ${{ secrets.OSSRH_PASS }}
+          MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
         # It will still check the remote but hopefully not download much (0 B at 0 B/s). -o isn't safe because of MDEP-82 (see above).
         run: |
@@ -84,8 +81,8 @@ jobs:
       - name: Perform release
         if: github.event.inputs.perform_version != ''
         env:
-          OSSRH_USER: ${{ secrets.OSSRH_USER }}
-          OSSRH_PASS: ${{ secrets.OSSRH_PASS }}
+          MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
         # It will still check the remote but hopefully not download much (0 B at 0 B/s). -o isn't safe because of MDEP-82 (see above).
         # See https://issues.apache.org/jira/browse/SCM-729 for why the release.properties file is required.

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -8,5 +8,5 @@ jobs:
   snapshot:
     uses: killbill/gh-actions-shared/.github/workflows/snapshot.yml@java21
     secrets:
-      OSSRH_USER: ${{ secrets.OSSRH_USER }}
-      OSSRH_PASS: ${{ secrets.OSSRH_PASS }}
+      MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
+      MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   snapshot:
-    uses: killbill/gh-actions-shared/.github/workflows/snapshot.yml@main
+    uses: killbill/gh-actions-shared/.github/workflows/snapshot.yml@java21
     secrets:
       OSSRH_USER: ${{ secrets.OSSRH_USER }}
       OSSRH_PASS: ${{ secrets.OSSRH_PASS }}

--- a/catalog/pom.xml
+++ b/catalog/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.kill-bill.billing.plugin</groupId>
         <artifactId>killbill-plugin-api</artifactId>
-        <version>0.27.4-SNAPSHOT</version>
+        <version>0.28.0-SNAPSHOT</version>
     </parent>
     <artifactId>killbill-plugin-api-catalog</artifactId>
     <name>Kill Bill catalog plugin apis</name>

--- a/control/pom.xml
+++ b/control/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.kill-bill.billing.plugin</groupId>
         <artifactId>killbill-plugin-api</artifactId>
-        <version>0.27.4-SNAPSHOT</version>
+        <version>0.28.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-plugin-api-control</artifactId>

--- a/currency/pom.xml
+++ b/currency/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.kill-bill.billing.plugin</groupId>
         <artifactId>killbill-plugin-api</artifactId>
-        <version>0.27.4-SNAPSHOT</version>
+        <version>0.28.0-SNAPSHOT</version>
     </parent>
     <artifactId>killbill-plugin-api-currency</artifactId>
     <name>Kill Bill currency conversion plugin apis</name>

--- a/entitlement/pom.xml
+++ b/entitlement/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.kill-bill.billing.plugin</groupId>
         <artifactId>killbill-plugin-api</artifactId>
-        <version>0.27.4-SNAPSHOT</version>
+        <version>0.28.0-SNAPSHOT</version>
     </parent>
     <artifactId>killbill-plugin-api-entitlement</artifactId>
     <name>Kill Bill entitlement plugin apis</name>

--- a/invoice/pom.xml
+++ b/invoice/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.kill-bill.billing.plugin</groupId>
         <artifactId>killbill-plugin-api</artifactId>
-        <version>0.27.4-SNAPSHOT</version>
+        <version>0.28.0-SNAPSHOT</version>
     </parent>
     <artifactId>killbill-plugin-api-invoice</artifactId>
     <name>Kill Bill invoice plugin apis</name>

--- a/notification/pom.xml
+++ b/notification/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.kill-bill.billing.plugin</groupId>
         <artifactId>killbill-plugin-api</artifactId>
-        <version>0.27.4-SNAPSHOT</version>
+        <version>0.28.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-plugin-api-notification</artifactId>

--- a/payment/pom.xml
+++ b/payment/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.kill-bill.billing.plugin</groupId>
         <artifactId>killbill-plugin-api</artifactId>
-        <version>0.27.4-SNAPSHOT</version>
+        <version>0.28.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-plugin-api-payment</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     </parent>
     <groupId>org.kill-bill.billing.plugin</groupId>
     <artifactId>killbill-plugin-api</artifactId>
-    <version>0.27.4-SNAPSHOT</version>
+    <version>0.28.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Kill Bill plugin apis</name>
     <description>Kill Bill plugin apis</description>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-oss-parent</artifactId>
-        <version>0.146.27</version>
+        <version>0.147.2</version>
     </parent>
     <groupId>org.kill-bill.billing.plugin</groupId>
     <artifactId>killbill-plugin-api</artifactId>

--- a/usage/pom.xml
+++ b/usage/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.kill-bill.billing.plugin</groupId>
         <artifactId>killbill-plugin-api</artifactId>
-        <version>0.27.4-SNAPSHOT</version>
+        <version>0.28.0-SNAPSHOT</version>
     </parent>
     <artifactId>killbill-plugin-api-usage</artifactId>
     <name>Kill Bill usage plugin apis</name>


### PR DESCRIPTION
As described in title. Commits are self-explanatory. There's no (java) code that contains jakarta import.